### PR TITLE
Remove cheerio dep + Add pagination support + Improve output format

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ var args = process.argv.slice(
 );
 if(!module.parent) main(args);
 
+function commaNum(n) {
+  return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
 function main(args) {
   if(args.indexOf('-h') !== -1 || args.indexOf('--help') !== -1) {
     console.log('Usage: am-i-used');
@@ -42,7 +46,7 @@ function main(args) {
         var total = ds.reduce(function(x, m) { return x + m; }, 0);
 
         console.log(
-          'Your packages have been downloaded ' + total + ' times last month.'
+          'Your packages have been downloaded ' + commaNum(total) + ' times last month.'
         );
 
         console.log(
@@ -50,7 +54,7 @@ function main(args) {
         );
 
         for(var i = 0, len = ds.length; i < len; i++) {
-          console.log(packagenames[i] + ' - ' + ds[i]);
+          console.log(packagenames[i] + ' - ' + commaNum(ds[i]));
         }
 
         cb();

--- a/index.js
+++ b/index.js
@@ -98,8 +98,9 @@ function getPackagesFromNpm(username, cb) {
   getPackageCountFromNpm(username, function (err, total, itemCount) {
     if (err) return cb(err);
     var totalOffsets = Math.ceil(total / 100);
-    async.times(
+    async.timesLimit(
       totalOffsets,
+      2, // let's be nice to NPM.
       function (i, cb) {
         request
           .get('https://www.npmjs.com/profile/' + username + '/packages?offset=' + i)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/yamadapc/am-i-used",
   "dependencies": {
-    "cheerio": "^0.20.0",
+    "async": "^2.1.4",
     "superagent": "^0.21.0"
   }
 }


### PR DESCRIPTION
Did three things in this PR (finally - it's been bugging me):

- Removed the need for the hairy `cheerio` dependency. This now uses npm's REST API directly.
- Added ability to traverse _all_ packages by a user (test this using `am-i-used sindresorhus`)
- Added commas to all of the download counts because I'm a little dyslexci.